### PR TITLE
add more logging and do minor refactoring

### DIFF
--- a/bot_logger.rb
+++ b/bot_logger.rb
@@ -1,0 +1,21 @@
+require 'logger'
+
+class BotLogger < Logger
+
+  def initialize(botname)
+    super("/tmp/#{botname}.log")
+    @level = DEBUG
+    @num_seen = 0
+  end
+
+  def tweet_attempt(tweet)
+    @num_seen += 1
+    debug "Trying to generate based on tweet id #{tweet.id}"
+  end
+
+  def done
+    debug "Done processing home_timeline; processed #{@num_seen} tweets"
+    @num_seen = 0
+  end
+
+end


### PR DESCRIPTION
This commit also adds support for a :debug: key in the config file;
setting this to true will prevent the bot from tweeting.

I also took out the update to :since_id: since upon reviewing the
home_timeline method in the Chatterbot code since_id is updated for each
home_timeline tweet before our block even runs.
